### PR TITLE
chore: enable dependabot gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+ - package-ecosystem: "gomod"
+   directory: "/"
+   schedule:
+     interval: daily
  - package-ecosystem: "devcontainers"
    directory: "/"
    schedule:


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to add support for Go modules. The update specifies the package ecosystem as "gomod" and sets the update schedule to daily.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R3-R6): Added configuration to support Go modules with daily update schedule.