### PR TITLE
feat: prepare for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683               # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34               # v5.3.0
+        with:
+          go-version: stable
+      - uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3   # v6.2.1
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:
@@ -13,15 +13,14 @@ builds:
     goos:
       - linux
       - darwin
-
-archives:
-  - format: tar.gz
-    name_template: >-
-      {{ .ProjectName }}-
-      {{- .Os }}-
-      {{- if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.buildVersion={{.Version}}
+      - -X main.buildCommit={{.Commit}}
+      - -X main.buildDate={{.Date}}
 
 changelog:
   sort: asc

--- a/flake.nix
+++ b/flake.nix
@@ -14,14 +14,20 @@
   }:
     utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {inherit system;};
+      version = "SNAPSHOT";
     in {
       packages = {
         default = pkgs.buildGo123Module {
+          inherit version;
           pname = "a555watch";
-          version = "1.0.0";
           src = ./.;
           vendorHash = null;
           env.CGO_ENABLED = 0;
+          ldflags = [
+            "-X main.buildVersion=${version}"
+            "-X main.buildCommit=${self.rev or "dirty"}"
+            "-X main.buildDate=${self.lastModifiedDate}"
+          ];
         };
       };
 

--- a/justfile
+++ b/justfile
@@ -1,5 +1,13 @@
 program := 'a555watch'
 
+version := 'SNAPSHOT-'+`git describe --tags --always --dirty`
+commit_sha := `git rev-parse HEAD`
+build_time := `date -u '+%Y-%m-%d_%H:%M:%S'`
+
+ldflags := '-s -w -X main.buildVersion='+version \
+        +' -X main.buildCommit='+commit_sha \
+        +' -X main.buildDate='+build_time
+
 goos := if os() == 'macos' { 'darwin' } else { os() }
 goarch := if arch() == 'aarch64' { 'arm64' } else { arch() }
 
@@ -9,7 +17,10 @@ alias r := run-local
 build-all: (build 'darwin' 'arm64') (build 'linux' 'arm64') (build 'linux' 'amd64')
 
 build os=goos arch=goarch: build-dir
-    CGO_ENABLED=0 GOOS={{os}} GOARCH={{arch}} go build -o build/{{program}}-{{os}}-{{arch}}
+    CGO_ENABLED=0 GOOS={{os}} GOARCH={{arch}} \
+        go build \
+            -ldflags '{{ldflags}}' \
+            -o build/{{program}}-{{os}}-{{arch}}
 
 build-dir:
     mkdir -p build

--- a/main.go
+++ b/main.go
@@ -31,10 +31,18 @@ var (
 	flagLog      = flag.String("log", "", "write debug logs to file")
 	flagDebug    = flag.Bool("debug", false, "enable tracing logs")
 	flagHelp     = flag.BoolP("help", "h", false, "display this help and exit")
+	flagVersion  = flag.BoolP("version", "V", false, "show binary version")
 )
 
 //go:embed banner.txt
 var banner string
+
+// Version information filled at build time
+var (
+	buildVersion = "SNAPSHOT"
+	buildCommit  = "unknown"
+	buildDate    = "1970-01-01"
+)
 
 var (
 	colorDark   = lipgloss.Color("55")
@@ -848,6 +856,11 @@ func main() {
 	flag.Parse()
 	if *flagHelp {
 		flag.Usage()
+		os.Exit(0)
+	}
+
+	if *flagVersion {
+		fmt.Printf("%s version %s (%s) built at %s\n", os.Args[0], buildVersion, buildCommit, buildDate)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This pull request includes several changes to automate the release process and improve versioning in the build system. The most important changes include the addition of a GitHub Actions workflow for releases, updates to the GoReleaser configuration, and modifications to include version information in the build process.

### Release Automation:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R27): Added a new GitHub Actions workflow to automate the release process on tag pushes. This workflow uses `actions/checkout`, `actions/setup-go`, and `goreleaser/goreleaser-action` to manage the release.

### GoReleaser Configuration:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L4-R4): Updated the GoReleaser configuration to version 2 and modified the `builds` section to include `goarch` and `ldflags` for embedding version information. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L4-R4) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L16-R23)

### Build System Enhancements:

* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R17-R30): Updated the Nix flake to include version, commit, and date information in the Go build process using `ldflags`.
* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R3-R10): Added variables for version, commit SHA, and build time, and updated the build command to include these in the `ldflags`. [[1]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R3-R10) [[2]](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1L12-R23)

### Version Information in Binary:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R34-R46): Added flags and variables to display version information, and updated the `main` function to print this information when the `--version` flag is used. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R34-R46) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R862-R866)